### PR TITLE
인증에 필요한 추가 사항 PR

### DIFF
--- a/core/src/main/kotlin/xyz/neonkid/cms/core/CoreConfig.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/core/CoreConfig.kt
@@ -13,7 +13,7 @@ import xyz.neonkid.cms.core.jdbc.JdbcConfig
  * Github : https://github.com/NEONKID
  */
 @Configuration
-@ComponentScan(basePackages = ["xyz.neonkid.cms.common.errors", "xyz.neonkid.cms.modules", "xyz.neonkid.cms.core.utils"])
+@ComponentScan(basePackages = ["xyz.neonkid.cms.common.errors", "xyz.neonkid.cms.modules", "xyz.neonkid.cms.core"])
 @EnableJdbcAuditing
 @EnableJdbcRepositories(value = ["xyz.neonkid.cms.core", "xyz.neonkid.cms.persistence"])
 @Import(JdbcConfig::class)

--- a/core/src/main/kotlin/xyz/neonkid/cms/core/CoreConfig.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/core/CoreConfig.kt
@@ -13,7 +13,7 @@ import xyz.neonkid.cms.core.jdbc.JdbcConfig
  * Github : https://github.com/NEONKID
  */
 @Configuration
-@ComponentScan(basePackages = ["xyz.neonkid.cms.common.errors", "xyz.neonkid.cms.modules", "xyz.neonkid.cms.core"])
+@ComponentScan(basePackages = ["xyz.neonkid.cms.core", "xyz.neonkid.cms.common.errors", "xyz.neonkid.cms.modules"])
 @EnableJdbcAuditing
 @EnableJdbcRepositories(value = ["xyz.neonkid.cms.core", "xyz.neonkid.cms.persistence"])
 @Import(JdbcConfig::class)

--- a/core/src/main/kotlin/xyz/neonkid/cms/core/interceptor/PermissionInterceptor.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/core/interceptor/PermissionInterceptor.kt
@@ -27,8 +27,10 @@ class PermissionInterceptor(
         val token = extractJwtTokenFromHeader(request)
         val payload = jwtTokenUtils.getPayload(token)
 
-        if (permission.role == PermissionRole.ADMIN)
-            return true
+        if (permission.role == PermissionRole.ADMIN) {
+            if (payload.isAdmin)
+                return true
+        }
 
         throw Exception()
     }

--- a/core/src/main/kotlin/xyz/neonkid/cms/core/jdbc/JdbcConfig.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/core/jdbc/JdbcConfig.kt
@@ -10,7 +10,7 @@ import xyz.neonkid.cms.persistence.user.BeforeSaveUserCallback
 /**
  * Created by Neon K.I.D on 1/8/22
  * Blog : https://blog.neonkid.xyz
- * Github : https://github.com/NEONKID
+ * GitHub : https://github.com/NEONKID
  */
 @Configuration
 class JdbcConfig : AbstractJdbcConfiguration() {

--- a/core/src/main/kotlin/xyz/neonkid/cms/core/resolver/CurrentUserArgumentResolver.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/core/resolver/CurrentUserArgumentResolver.kt
@@ -7,7 +7,7 @@ import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
 import xyz.neonkid.cms.core.interceptor.AuthenticationException
-import xyz.neonkid.cms.manager.core.utils.JwtTokenUtils
+import xyz.neonkid.cms.core.utils.JwtTokenUtils
 
 /**
  * Created by Neon K.I.D on 2/19/22

--- a/core/src/main/kotlin/xyz/neonkid/cms/core/utils/ApiUtils.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/core/utils/ApiUtils.kt
@@ -12,22 +12,20 @@ import org.springframework.http.HttpStatus
 class ApiError internal constructor(val message: String?, val status: HttpStatus) {
     internal constructor(throwable: Throwable, status: HttpStatus) : this(throwable.message, status)
 
-    override fun toString(): String {
-        return ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+    override fun toString() =
+        ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
             .append("message", message)
             .append("status", status)
             .toString()
-    }
 }
 
 class ApiResult<T> (@get:JvmName("isSuccess") val success: Boolean, val response: T, val error: ApiError?) {
-    override fun toString(): String {
-        return ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+    override fun toString() =
+        ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
             .append("success", success)
             .append("response", response)
             .append("error", error)
             .toString()
-    }
 }
 
 fun <T> success(response: T) = ApiResult(true, response, null)

--- a/core/src/main/kotlin/xyz/neonkid/cms/core/utils/JwtUtils.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/core/utils/JwtUtils.kt
@@ -62,10 +62,12 @@ class JwtTokenUtils {
 
     fun getPayload(token: String): JwtTokenPayload {
         val claims = decode(token)
-        val userId = claims[JwtTokenPayloadKeySet.USER_ID.toString()].toString().toInt()
-        val isAdmin = claims[JwtTokenPayloadKeySet.IS_ADMIN.toString()].toString().toBoolean()
 
-        return JwtTokenPayload(userId.toLong(), isAdmin, false)
+        val userId = claims[JwtTokenPayloadKeySet.USER_ID.toString()].toString().toLong()
+        val isAdmin = claims[JwtTokenPayloadKeySet.IS_ADMIN.toString()].toString().toBoolean()
+        val refresh = claims[JwtTokenPayloadKeySet.REFRESH.toString()].toString().toBoolean()
+
+        return JwtTokenPayload(userId, isAdmin, refresh)
     }
 
     private fun makeHeader() = mapOf(

--- a/core/src/main/kotlin/xyz/neonkid/cms/core/utils/JwtUtils.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/core/utils/JwtUtils.kt
@@ -63,7 +63,9 @@ class JwtTokenUtils {
     fun getPayload(token: String): JwtTokenPayload {
         val claims = decode(token)
         val userId = claims[JwtTokenPayloadKeySet.USER_ID.toString()].toString().toInt()
-        return JwtTokenPayload(userId.toLong(), false)
+        val isAdmin = claims[JwtTokenPayloadKeySet.IS_ADMIN.toString()].toString().toBoolean()
+
+        return JwtTokenPayload(userId.toLong(), isAdmin, false)
     }
 
     private fun makeHeader() = mapOf(
@@ -80,11 +82,12 @@ class JwtTokenUtils {
 
 data class JwtTokenPayload(
     val userId: Long,
+    val isAdmin: Boolean,
     val refresh: Boolean
 )
 
 enum class JwtTokenPayloadKeySet {
-    USER_ID, REFRESH;
+    USER_ID, IS_ADMIN, REFRESH;
 
     override fun toString() = name.lowercase()
 }

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/domain/aggregate/User.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/domain/aggregate/User.kt
@@ -1,9 +1,6 @@
 package xyz.neonkid.cms.modules.user.domain.aggregate
 
-import xyz.neonkid.cms.modules.user.domain.valueObjects.Email
-import xyz.neonkid.cms.modules.user.domain.valueObjects.NickName
-import xyz.neonkid.cms.modules.user.domain.valueObjects.Password
-import xyz.neonkid.cms.modules.user.domain.valueObjects.UserDateTime
+import xyz.neonkid.cms.modules.user.domain.valueObjects.*
 import xyz.neonkid.cms.modules.user.useCases.commands.CreateUserCommand
 
 /**
@@ -14,8 +11,9 @@ import xyz.neonkid.cms.modules.user.useCases.commands.CreateUserCommand
 data class User (
     val id: UserId,
     val email: Email,
-    val nickName: NickName,
-    val password: Password,
+    var nickName: NickName,
+    var password: Password,
+    var isAdmin: IsAdmin,
     val createdAt: UserDateTime?,
     val updatedAt: UserDateTime?
 ) {
@@ -25,6 +23,7 @@ data class User (
             command.email,
             command.nickname,
             command.password,
+            IsAdmin(false),
             null, null
         )
     }

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/domain/valueObjects/IsAdmin.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/domain/valueObjects/IsAdmin.kt
@@ -1,0 +1,17 @@
+package xyz.neonkid.cms.modules.user.domain.valueObjects
+
+import org.valiktor.functions.isNotNull
+import org.valiktor.validate
+
+/**
+ * Created by Neon K.I.D on 3/6/22
+ * Blog : https://blog.neonkid.xyz
+ * Github : https://github.com/NEONKID
+ */
+data class IsAdmin(val value: Boolean) {
+    init {
+        validate(this) {
+            validate(IsAdmin::value).isNotNull()
+        }
+    }
+}

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/infrastructure/persistence/UserMapper.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/infrastructure/persistence/UserMapper.kt
@@ -3,10 +3,7 @@ package xyz.neonkid.cms.modules.user.infrastructure.persistence
 import xyz.neonkid.cms.common.interfaces.ModelMapper
 import xyz.neonkid.cms.modules.user.domain.aggregate.User
 import xyz.neonkid.cms.modules.user.domain.aggregate.UserId
-import xyz.neonkid.cms.modules.user.domain.valueObjects.Email
-import xyz.neonkid.cms.modules.user.domain.valueObjects.NickName
-import xyz.neonkid.cms.modules.user.domain.valueObjects.Password
-import xyz.neonkid.cms.modules.user.domain.valueObjects.UserDateTime
+import xyz.neonkid.cms.modules.user.domain.valueObjects.*
 import xyz.neonkid.cms.persistence.user.UserEntity
 
 /**
@@ -21,6 +18,7 @@ object UserMapper : ModelMapper<User, UserEntity> {
             Email(model.email),
             NickName(model.nickname),
             Password(model.password),
+            IsAdmin(model.isAdmin),
             model.createdAt?.let { UserDateTime(model.createdAt) },
             UserDateTime(model.updatedAt)
         )
@@ -31,6 +29,7 @@ object UserMapper : ModelMapper<User, UserEntity> {
             model.email.value,
             model.nickName.value,
             model.password.value,
+            model.isAdmin.value,
             model.createdAt?.value
         )
 }

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/AssignAdmin.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/AssignAdmin.kt
@@ -1,0 +1,29 @@
+package xyz.neonkid.cms.modules.user.useCases.commands
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import xyz.neonkid.cms.common.interfaces.UseCase
+import xyz.neonkid.cms.modules.user.domain.aggregate.UserId
+import xyz.neonkid.cms.modules.user.domain.valueObjects.IsAdmin
+import xyz.neonkid.cms.modules.user.infrastructure.persistence.UserPersistenceAdapter
+import xyz.neonkid.cms.modules.user.useCases.queries.UserQueryRepository
+
+/**
+ * Created by Neon K.I.D on 3/6/22
+ * Blog : https://blog.neonkid.xyz
+ * Github : https://github.com/NEONKID
+ */
+@Service
+@Transactional
+class AssignAdminUseCase(
+    private val userPersistenceAdapter: UserPersistenceAdapter
+) : UseCase<AssignAdminCommand, Unit> {
+    override fun invoke(command: AssignAdminCommand) {
+        val user = userPersistenceAdapter.findById(command.userId)
+        user.isAdmin = IsAdmin(true)
+
+        userPersistenceAdapter.update(user)
+    }
+}
+
+data class AssignAdminCommand(val userId: UserId)

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/AssignMember.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/AssignMember.kt
@@ -1,0 +1,29 @@
+package xyz.neonkid.cms.modules.user.useCases.commands
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import xyz.neonkid.cms.common.interfaces.UseCase
+import xyz.neonkid.cms.modules.user.domain.aggregate.UserId
+import xyz.neonkid.cms.modules.user.domain.valueObjects.IsAdmin
+import xyz.neonkid.cms.modules.user.infrastructure.persistence.UserPersistenceAdapter
+import xyz.neonkid.cms.modules.user.useCases.queries.UserQueryRepository
+
+/**
+ * Created by Neon K.I.D on 3/6/22
+ * Blog : https://blog.neonkid.xyz
+ * Github : https://github.com/NEONKID
+ */
+@Service
+@Transactional
+class AssignMemberUseCase(
+    private val userPersistenceAdapter: UserPersistenceAdapter
+): UseCase<AssignMemberCommand, Unit> {
+    override fun invoke(command: AssignMemberCommand) {
+        val user = userPersistenceAdapter.findById(command.userId)
+        user.isAdmin = IsAdmin(false)
+
+        userPersistenceAdapter.update(user)
+    }
+}
+
+data class AssignMemberCommand(val userId: UserId)

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/CreateUser.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/CreateUser.kt
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import xyz.neonkid.cms.common.interfaces.UseCase
 import xyz.neonkid.cms.modules.user.domain.aggregate.User
 import xyz.neonkid.cms.modules.user.domain.valueObjects.Email
+import xyz.neonkid.cms.modules.user.domain.valueObjects.IsAdmin
 import xyz.neonkid.cms.modules.user.domain.valueObjects.NickName
 import xyz.neonkid.cms.modules.user.domain.valueObjects.Password
 import xyz.neonkid.cms.modules.user.infrastructure.persistence.UserPersistenceAdapter

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/LoginUser.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/LoginUser.kt
@@ -25,7 +25,7 @@ class LoginUserUseCase(
         if (user.password != command.password)
             throw IllegalArgumentException("Password is incorrect")
 
-        val accessToken = jwtTokenUtils.encode(mapOf("user_id" to user.id))
+        val accessToken = jwtTokenUtils.encode(mapOf("user_id" to user.id), 1800)
         val refreshToken = jwtTokenUtils.encode(mapOf("user_id" to user.id), 3600 * 24)
 
         return TokenDTO(accessToken, refreshToken)

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/LoginUser.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/LoginUser.kt
@@ -25,8 +25,8 @@ class LoginUserUseCase(
         if (user.password != command.password)
             throw IllegalArgumentException("Password is incorrect")
 
-        val accessToken = jwtTokenUtils.encode(mapOf("user_id" to user.id), 1800)
-        val refreshToken = jwtTokenUtils.encode(mapOf("user_id" to user.id), 3600 * 24)
+        val accessToken = jwtTokenUtils.encode(mapOf("user_id" to user.id, "is_admin" to user.isAdmin), 1800)
+        val refreshToken = jwtTokenUtils.encode(mapOf("user_id" to user.id, "is_admin" to user.isAdmin), 3600 * 24)
 
         return TokenDTO(accessToken, refreshToken)
     }

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/LoginUser.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/LoginUser.kt
@@ -26,7 +26,9 @@ class LoginUserUseCase(
             throw IllegalArgumentException("Password is incorrect")
 
         val accessToken = jwtTokenUtils.encode(mapOf("user_id" to user.id))
-        return TokenDTO(accessToken)
+        val refreshToken = jwtTokenUtils.encode(mapOf("user_id" to user.id), 3600 * 24)
+
+        return TokenDTO(accessToken, refreshToken)
     }
 }
 

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/LoginUser.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/commands/LoginUser.kt
@@ -25,8 +25,12 @@ class LoginUserUseCase(
         if (user.password != command.password)
             throw IllegalArgumentException("Password is incorrect")
 
-        val accessToken = jwtTokenUtils.encode(mapOf("user_id" to user.id, "is_admin" to user.isAdmin), 1800)
-        val refreshToken = jwtTokenUtils.encode(mapOf("user_id" to user.id, "is_admin" to user.isAdmin), 3600 * 24)
+        val accessToken = jwtTokenUtils.encode(
+            mapOf("user_id" to user.id, "is_admin" to user.isAdmin, "refresh" to false),
+            1800)
+        val refreshToken = jwtTokenUtils.encode(
+            mapOf("user_id" to user.id, "is_admin" to user.isAdmin, "refresh" to true),
+            3600 * 24)
 
         return TokenDTO(accessToken, refreshToken)
     }

--- a/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/queries/dto/TokenDTO.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/modules/user/useCases/queries/dto/TokenDTO.kt
@@ -4,5 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class TokenDTO @JsonCreator constructor(
-    @JsonProperty("access_token") val accessToken: String
+    @JsonProperty("access_token") val accessToken: String,
+    @JsonProperty("refresh_token") val refreshToken: String
 )

--- a/core/src/main/kotlin/xyz/neonkid/cms/persistence/user/UserEntity.kt
+++ b/core/src/main/kotlin/xyz/neonkid/cms/persistence/user/UserEntity.kt
@@ -22,6 +22,7 @@ data class UserEntity (
     val email: String,
     val nickname: String,
     val password: String,
+    val isAdmin: Boolean,
     @CreatedDate @Column("created_at") var createdAt: LocalDateTime?
 ) {
     @LastModifiedDate @Column("updated_at") var updatedAt: LocalDateTime = LocalDateTime.MIN

--- a/core/src/main/resources/db/migration/V1.0.2__add_user_schema.sql
+++ b/core/src/main/resources/db/migration/V1.0.2__add_user_schema.sql
@@ -9,6 +9,7 @@ create table if not exists public.users (
     email varchar(128) NOT NULL,
     nickname varchar(20) NOT NULL,
     password varchar(1024) NOT NULL,
+    is_admin boolean NOT NULL,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL,
     deleted_at TIMESTAMP

--- a/manager-api/src/main/kotlin/xyz/neonkid/cms/manager/api/v1/UserController.kt
+++ b/manager-api/src/main/kotlin/xyz/neonkid/cms/manager/api/v1/UserController.kt
@@ -3,6 +3,7 @@ package xyz.neonkid.cms.manager.api.v1
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -32,6 +33,8 @@ class UserController(
     private val createUserUseCase: CreateUserUseCase,
     private val deleteUserUseCase: DeleteUserUseCase,
     private val loginUserUseCase: LoginUserUseCase,
+    private val assignAdminUseCase: AssignAdminUseCase,
+    private val assignMemberUseCase: AssignMemberUseCase,
 
     private val userQueryRepository: UserQueryRepository
 ) {
@@ -59,6 +62,18 @@ class UserController(
                 Password(req.password)
             ))
         )
+
+    @Permission(PermissionRole.ADMIN)
+    @PatchMapping("{userId}/admin")
+    fun assignAdmin(@PathVariable userId: Long) {
+        success(assignAdminUseCase.invoke(AssignAdminCommand(UserId(userId))))
+    }
+
+    @Permission(PermissionRole.ADMIN)
+    @PatchMapping("{userId}/member")
+    fun assignMember(@PathVariable userId: Long) {
+        success(assignMemberUseCase.invoke(AssignMemberCommand(UserId(userId))))
+    }
 
     @Permission(PermissionRole.ADMIN)
     @DeleteMapping("/{id}")


### PR DESCRIPTION
Fixed #5 
User Persistence Entity에서 ```is_admin```컬럼을 추가하고, 이를 통해 payload에 권한의 여부를 결정

추가사항:
* Domain Entity, Persistence Entity에 ```is_admin``` 멤버 추가
* token payload에서 구분할 수 있도록 token payload에 ```is_admin``` key 추가
* ```is_admin``` 컬럼을 바꿀 수 있는 두 개의 useCase 추가